### PR TITLE
Live analysis v2.0

### DIFF
--- a/alertConfiguration.json
+++ b/alertConfiguration.json
@@ -24,6 +24,7 @@
 		"topAssetsFilterThreshold": 5,
 		"topAssetsMaxRank": 15
 	},
+	"timeZoneHour": 5,
 	"volume": {
 		"nightmode": {
 			"default": 10,

--- a/alertConfiguration.json
+++ b/alertConfiguration.json
@@ -1,0 +1,37 @@
+{
+	"alerts": {
+		"btc_more": {
+			"symbol": "BTC",
+			"price": "2850",
+			"band": "MORE"
+		},
+		"btc_less": {
+			"symbol": "BTC",
+			"price": "2400",
+			"band": "LESS"
+		}
+	},
+	"bot_options": {
+		"voice": "-v Daniel",
+		"word_rate": "-r 210"
+	},
+	"init_params": {
+		
+	},
+	"runtime_params": {
+		"coinsToMonitor": [ "BTC", "LTC", "GNT", "ETH", "DASH", "XRP", "XMR", "ANT", "REP", "DCR", "EOS", "GNO"],
+		
+		"topAssetsFilterThreshold": 5,
+		"topAssetsMaxRank": 15
+	},
+	"volume": {
+		"nightmode": {
+			"default": 10,
+			"alert": 15
+		},
+		"daymode": {
+			"default": 40,
+			"alert": 60
+		}
+	}
+}

--- a/coinalert.py
+++ b/coinalert.py
@@ -36,9 +36,10 @@ Submodule to send out alerts on the mac system
 class Alerter:
 
 	# convert gmt hour to ist by adding offset 
-	# for hours (+30min is ignored as of now)
-	def toIST(self, gmHour):
-		return (gmHour + 5)%24
+	# for hours
+	def toLocalTime(self, gmHour, configuration):
+		totTime = 24 + int(configuration["timeZoneHour"])	#since it can be -ve and modulus of -ve is not same as +ve numbers
+		return (gmHour + totTime)%24
 
 	# Decides if it is night time or not
 	def isNightTime(self, hour):
@@ -53,8 +54,8 @@ class Alerter:
 	def doAlert(self, message, mode, configuration):
 
 		gmHourNow = strftime("%H", gmtime())
-		istHour = self.toIST(int(gmHourNow))
-		isItNight = self.isNightTime(istHour)
+		localHour = self.toLocalTime(int(gmHourNow), configuration)
+		isItNight = self.isNightTime(localHour)
 
 		#osascript subcommand string
 		volcontroller = 'set volume output volume '


### PR DESCRIPTION
Almost all major configurations have been moved to JSON config so that program will not have to be stopped after a parameter update and can continue running on the fly. This will help the future development when live analysis of moving averages and other study patterns are mixed and attached to this bot.

**The following can now be done without stopping the running bot:**
- Now add/remove the coins you want to monitor/remove on the go in the ticker by directly updating the config in one shot save.
- Now directly tune the X top gainers and losers from the top Y currencies (their rank on coinmarketcap.com) and get their live stat on the terminal.
- Adjust the volume you want your mac to speak up for normal price jumps/drop or a major threshold alert. 
- Add/remove/modify the threshold for coin prices (e.g. dropping below a limit or soaring above a price) on the go, which would create special alerts and additional volume support for that (e.g. you might want the system to speak more loudly in such a situation).

Screenshot of the current output:
![image](https://user-images.githubusercontent.com/5751535/28757796-631e9186-75a8-11e7-8bff-c6869a32b6d9.png)
